### PR TITLE
include the profile in MediaDetailed

### DIFF
--- a/src/Instagram/Hydrator/MediaHydrator.php
+++ b/src/Instagram/Hydrator/MediaHydrator.php
@@ -124,6 +124,12 @@ class MediaHydrator
 
         $media->setTaggedUsers($taggedUsers);
 
+        if (property_exists($node, 'owner')) {
+            $hydrator = new ProfileHydrator();
+            $hydrator->hydrateProfile($node->owner);
+            $media->setProfile($hydrator->getProfile());
+        }
+
         if ($node->__typename === 'GraphSidecar') {
             $scItems = [];
             foreach ($node->edge_sidecar_to_children->edges as $item) {

--- a/src/Instagram/Hydrator/ProfileHydrator.php
+++ b/src/Instagram/Hydrator/ProfileHydrator.php
@@ -38,14 +38,28 @@ class ProfileHydrator
         $this->profile->setId32Bit($data->id);
         $this->profile->setUserName($data->username);
         $this->profile->setFullName($data->full_name);
-        $this->profile->setBiography($data->biography);
-        $this->profile->setExternalUrl($data->external_url);
         $this->profile->setFollowers($data->edge_followed_by->count);
-        $this->profile->setFollowing($data->edge_follow->count);
-        $this->profile->setProfilePicture($data->profile_pic_url_hd);
         $this->profile->setPrivate($data->is_private);
         $this->profile->setVerified($data->is_verified);
         $this->profile->setMediaCount($data->edge_owner_to_timeline_media->count);
+
+        if (property_exists($data, 'biography')) {
+            $this->profile->setBiography($data->biography);
+        }
+
+        if (property_exists($data, 'external_url')) {
+            $this->profile->setExternalUrl($data->external_url);
+        }
+
+        if (property_exists($data, 'edge_follow')) {
+            $this->profile->setFollowing($data->edge_follow->count);
+        }
+
+        if (property_exists($data, 'profile_pic_url_hd')) {
+            $this->profile->setProfilePicture($data->profile_pic_url_hd);
+        } elseif (property_exists($data, 'profile_pic_url')) {
+            $this->profile->setProfilePicture($data->profile_pic_url);
+        }
     }
 
     /**

--- a/src/Instagram/Model/MediaDetailed.php
+++ b/src/Instagram/Model/MediaDetailed.php
@@ -30,6 +30,11 @@ class MediaDetailed extends Media
     private $displayResources = [];
 
     /**
+     * @var Instagram\Model\Profile
+     */
+    private $profile;
+
+    /**
      * @return string
      */
     public function getVideoUrl(): ?string
@@ -91,6 +96,22 @@ class MediaDetailed extends Media
     public function setDisplayResources(array $displayResources): void
     {
         $this->displayResources = $displayResources;
+    }
+
+    /**
+     * @return Profile
+     */
+    public function getProfile(): Profile
+    {
+        return $this->profile;
+    }
+
+    /**
+     * @param Instagram\Model\Profile
+     */
+    public function setProfile(Profile $profile)
+    {
+        $this->profile = $profile;
     }
 
     /**

--- a/tests/ApiTest.php
+++ b/tests/ApiTest.php
@@ -8,6 +8,7 @@ use Instagram\Api;
 use Instagram\Auth\Session;
 use Instagram\Exception\InstagramFetchException;
 use Instagram\Model\Media;
+use Instagram\Model\Profile;
 use PHPUnit\Framework\TestCase;
 use Symfony\Component\Cache\Adapter\FilesystemAdapter;
 
@@ -361,6 +362,7 @@ class ApiTest extends TestCase
         $this->assertCount(4, $mediaDetailed->getSideCarItems());
         $this->assertCount(3, $mediaDetailed->getDisplayResources());
 
+        $this->assertInstanceOf(Profile::class, $mediaDetailed->getProfile());
 
         $api->logout('username');
     }


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes

I used the ProfileHydrator for the owner property of the media response to create the Profile
Therefore i had to put some "if (property_exists(..." into the Hydrator,
because not everything is in included in the response