### PR TITLE
Setup better default value for challenge delay.

### DIFF
--- a/src/Instagram/Api.php
+++ b/src/Instagram/Api.php
@@ -61,7 +61,7 @@ class Api
     protected $session = null;
 
     /**
-     * @var int|null
+     * @var int
      */
     protected $challengeDelay;
 
@@ -70,7 +70,7 @@ class Api
      * @param ClientInterface|null $client
      * @param int|null $challengeDelay
      */
-    public function __construct(CacheItemPoolInterface $cachePool, ClientInterface $client = null, ?int $challengeDelay = null)
+    public function __construct(CacheItemPoolInterface $cachePool, ClientInterface $client = null, ?int $challengeDelay = 3)
     {
         $this->cachePool      = $cachePool;
         $this->client         = $client ?: new Client();

--- a/src/Instagram/Auth/Login.php
+++ b/src/Instagram/Auth/Login.php
@@ -33,7 +33,7 @@ class Login
     private $imapClient;
 
     /**
-     * @var int|null
+     * @var int
      */
     private $challengeDelay;
 
@@ -44,7 +44,7 @@ class Login
      * @param ImapClient|null $imapClient
      * @param int|null $challengeDelay
      */
-    public function __construct(ClientInterface $client, string $login, string $password, ?ImapClient $imapClient = null, ?int $challengeDelay = null)
+    public function __construct(ClientInterface $client, string $login, string $password, ?ImapClient $imapClient = null, ?int $challengeDelay = 3)
     {
         $this->client         = $client;
         $this->login          = $login;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Issue?        | Fixes `TypeError: Argument 4 passed to Instagram\Auth\Checkpoint\Challenge::__construct() must be of the type int, null given, called in src/Instagram/Auth/Login.php on line 134`
