### PR TITLE
Throw exception when unable to open IMAP stream.

### DIFF
--- a/src/Instagram/Auth/Checkpoint/ImapClient.php
+++ b/src/Instagram/Auth/Checkpoint/ImapClient.php
@@ -101,6 +101,9 @@ class ImapClient
     public function getLastInstagramEmailContent(int $try = 1): string
     {
         $resource  = imap_open('{' . $this->getServer() . '/' . $this->getConnectionType() . '/ssl}INBOX', $this->getLogin(), $this->getPassword());
+        if (!$resource) {
+          throw new InstagramAuthException('Unable to open IMAP stream.');
+        }
         $numberMax = imap_num_msg($resource);
 
         $foundCode = false;


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Issue?        | Fixes `TypeError: imap_num_msg() expects parameter 1 to be resource, bool given in imap_num_msg() (line 104 of src/Instagram/Auth/Checkpoint/ImapClient.php)`
