### PR TITLE
add check before setting comments and likes

### DIFF
--- a/src/Instagram/Hydrator/MediaDetailedHydrator.php
+++ b/src/Instagram/Hydrator/MediaDetailedHydrator.php
@@ -67,8 +67,10 @@ class MediaDetailedHydrator
         $media->setThumbnailSrc($thumbnailSrc);
         $media->setDisplaySrc($displaySrc);
 
-        $media->setComments($node->comment_count);
-        $media->setLikes($node->like_count);
+        if (isset($node->comment_count))
+            $media->setComments($node->comment_count);
+        if (isset($node->like_count))
+            $media->setLikes($node->like_count);
 
         $media->setLink(InstagramHelper::URL_BASE . "p/{$node->code}/");
 

--- a/src/Instagram/Hydrator/MediaDetailedHydrator.php
+++ b/src/Instagram/Hydrator/MediaDetailedHydrator.php
@@ -67,10 +67,13 @@ class MediaDetailedHydrator
         $media->setThumbnailSrc($thumbnailSrc);
         $media->setDisplaySrc($displaySrc);
 
-        if (isset($node->comment_count))
+        if (property_exists($node, 'comment_count')) {
             $media->setComments($node->comment_count);
-        if (isset($node->like_count))
+        }
+
+        if (property_exists($node, 'like_count')) {
             $media->setLikes($node->like_count);
+        }
 
         $media->setLink(InstagramHelper::URL_BASE . "p/{$node->code}/");
 


### PR DESCRIPTION
Users can disable comments and likes on their posts. If that happens, `$node->comment_count` will be null.

| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Issue?        | Fix #... (prefix each issue number with "Fix #", if any)
