### PR TITLE
Throw AuthException when profile data fetch fails due to checkpoint

### DIFF
--- a/src/Instagram/Transport/JsonProfileDataFeedV2.php
+++ b/src/Instagram/Transport/JsonProfileDataFeedV2.php
@@ -25,6 +25,9 @@ class JsonProfileDataFeedV2 extends AbstractDataFeed
                 'x-ig-app-id' => 936619743392459,
             ]);
         } catch (\Exception $e) {
+            if (str_contains($e->getMessage(), '{"message":"checkpoint_required"')) {
+                throw new InstagramAuthException("Checkpoint required", $e->getCode(), $e);
+            }
             throw new InstagramFetchException('Error: ' . $e->getMessage());
         }
 


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | no
| New feature?  | yes
| Issue?        | N/A

Sometimes Instagram throws up a checkpoint if it feels like media is being downloaded too quickly.  Here's what the actual exception looks like:
```plain
Instagram\Exception\InstagramFetchException Object
(
    [message:protected] => Error: Client error: `GET https://i.instagram.com/api/v1/users/web_profile_info/?username=pgrimaud` resulted in a `400 Bad Request` response:
{"message":"checkpoint_required","checkpoint_url":"https://i.instagram.com/challenge/?next=/api/v1/users/web_profile_inf (truncated...)

    [string:Exception:private] => 
    [code:protected] => 0
    [[file:protected](file:///protected)] => /path/to/vendor/pgrimaud/instagram-user-feed/src/Instagram/Transport/JsonProfileDataFeedV2.php
    [line:protected] => 28
    [trace:Exception:private] => (not shown in this issue)
```

Note we cannot see the entire body because [the code that generates the exception](https://github.com/guzzle/guzzle/blob/7.8/src/Exception/RequestException.php#L107) [trims the body to 120 chars](https://github.com/guzzle/psr7/blob/2.6/src/Message.php#L56)