### PR TITLE
Do not run Pull Request unit tests on unsupported versions

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -9,11 +9,11 @@ jobs:
 
     strategy:
       matrix:
-        php: [ '7.2', '7.3', '7.4', '8', '8.1', '8.2', '8.3']
+        php: ['8.2', '8.3']
 
     steps:
       - name: "Init repository"
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: "Setup PHP"
         uses: shivammathur/setup-php@v2


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Issue?        | N/A

40763932f6c9796b33a9103fc258079bbe05d22c dropped support for PHP versions < 8.2

In addition, upgrade to checkout v4 to remove the warning about node 16