### PR TITLE
Add InstagramAuthException class for handling authentication errors

### DIFF
--- a/src/Instagram/Transport/JsonProfileDataFeedV2.php
+++ b/src/Instagram/Transport/JsonProfileDataFeedV2.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Instagram\Transport;
 
 use Instagram\Exception\InstagramFetchException;
+use Instagram\Exception\InstagramAuthException;
 use Instagram\Utils\InstagramHelper;
 
 class JsonProfileDataFeedV2 extends AbstractDataFeed
@@ -14,7 +15,7 @@ class JsonProfileDataFeedV2 extends AbstractDataFeed
      *
      * @return \StdClass
      *
-     * @throws InstagramFetchException
+     * @throws InstagramFetchException|InstagramAuthException
      */
     public function fetchData(string $username): \StdClass
     {


### PR DESCRIPTION
| Q             | A
| ------------- | ---
| Branch?       | master
| Bug fix?      | yes
| New feature?  | no
| Issue?        | My accounts got challenge required issue and system couldn't find the InstagramAuthException in JsonProfileDataFeedV2. That's why I added it.
